### PR TITLE
Added manager cookie secret to prevent saved form from breaking the settings form.

### DIFF
--- a/config/schema/gli_auth0.schema.yml
+++ b/config/schema/gli_auth0.schema.yml
@@ -1,0 +1,77 @@
+gli_auth0.settings:
+  type: config_object
+  label: 'GLI Auth0 settings'
+  mapping:
+    auth0:
+      label: 'Auth0 settings'
+      type: mapping
+      mapping:
+        domain:
+          label: 'Domain'
+          type: string
+        clientId:
+          label: 'Client ID'
+          type: string
+        clientSecret:
+          label: 'Client secret'
+          type: string
+        cookieSecret:
+          label: 'Cookie secret'
+          type: string
+        cookieExpires:
+          label: 'Cookie expires'
+          type: integer
+    manager:
+      label: 'Manager settings'
+      type: mapping
+      mapping:
+        domain:
+          label: 'Domain'
+          type: string
+        clientId:
+          label: 'Client ID'
+          type: string
+        clientSecret:
+          label: 'Client secret'
+          type: string
+        cookieSecret:
+          label: 'Cookie secret'
+          type: string
+    profile:
+      label: 'Profile settings'
+      type: mapping
+      mapping:
+        url:
+          label: 'URL'
+          type: uri
+        flow:
+          label: 'Flow'
+          type: mapping
+          mapping:
+            registration:
+              label: 'Registration'
+              type: mapping
+              mapping:
+                app_name:
+                  label: 'App name'
+                  type: string
+                component_name:
+                  label: 'Component name'
+                  type: string
+          profile:
+            label: 'Profile'
+            type: mapping
+            mapping:
+              app_name:
+                label: 'App name'
+                type: string
+              component_name:
+                label: 'Component name'
+                type: string
+    roles:
+      label: 'Roles'
+      type: sequence
+      orderby: key
+      sequence:
+        label: 'Role'
+        type: string

--- a/src/Form/Auth0Settings.php
+++ b/src/Form/Auth0Settings.php
@@ -139,6 +139,13 @@ final class Auth0Settings extends ConfigFormBase {
       '#default_value' => $config->get('manager')['clientSecret'] ?? '',
     ];
 
+    $form['manager']['cookieSecret'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Cookie Secret'),
+      '#description' => $this->t('Manager cookie secret.'),
+      '#default_value' => $config->get('manager')['cookieSecret'] ?? '',
+    ];
+
     $form['roles'] = [
       '#type' => 'details',
       '#title' => $this->t('Role Mapping'),


### PR DESCRIPTION
Without the addition below, the saving of the settings form will remove the manager cookie secret and throw an exception when it redirects back to the settings form.