### PR TITLE
Signup Link

### DIFF
--- a/gli_auth0.routing.yml
+++ b/gli_auth0.routing.yml
@@ -22,7 +22,7 @@ gli_auth0.signup:
   defaults:
     _controller: '\Drupal\gli_auth0\Controller\Auth0Controller::register'
   requirements:
-    access: 'TRUE'
+    _user_is_logged_in: 'FALSE'
 
 gli_auth0.callback:
   path: '/auth0/callback'


### PR DESCRIPTION
Fixes permission link related to accessing signup link

# Testing 

- Require version: `composer require drupal/gli_auth0:'dev-bug/fix-register-link'`
- Clear Drupal Cache `drush cr`
- Go to registration page: `/user/register`
- Confirm it redirects to the Auth0 Signup Page
<img width="436" alt="image" src="https://github.com/user-attachments/assets/4aeec4ea-99ec-497c-8f8c-291f7922b499">


# Troubleshooting
- In GLI there is a redirect in place `/admin/config/search/redirect/edit/400655` that will need to be deleted before