### PR TITLE
tw29777271 Fix: Roles lost when masquerading as user

### DIFF
--- a/modules/gli_auth0_roles_sync/gli_auth0_roles_sync.module
+++ b/modules/gli_auth0_roles_sync/gli_auth0_roles_sync.module
@@ -13,10 +13,20 @@ use Drupal\user\UserInterface;
 function gli_auth0_roles_sync_user_login(UserInterface $account) {
   /** @var \Drupal\gli_auth0\Service\Auth0Service $auth0 */
   $auth0 = \Drupal::service('gli_auth0');
+  $masquerade = \Drupal::hasService('masquerade') ? \Drupal::service('masquerade') : NULL;
+  $update_roles = FALSE;
 
   $auth0Id = $auth0->getUserAuth0Id($account->id());
   if ($auth0Id !== NULL) {
-    $auth0->updateUserRoles($auth0Id);
+    $update_roles = TRUE;
   }
 
+  if ($masquerade && $masquerade->isMasquerading()) {
+    // Skip updating roles when masquerading.
+    $update_roles = FALSE;
+  }
+
+  if ($update_roles) {
+    $auth0->updateUserRoles($auth0Id);
+  }
 }

--- a/src/Service/Auth0Service.php
+++ b/src/Service/Auth0Service.php
@@ -466,19 +466,21 @@ class Auth0Service {
       // Keep track if we should save the user.
       $save = FALSE;
 
-      // Loop through all currently mapped roles and remove them from the user.
-      foreach ($mappedDrupalRoles as $drupalRole) {
-        if ($user->hasRole($drupalRole)) {
-          $save = TRUE;
-          $user->removeRole($drupalRole);
+      if (!empty($auth0UserRoles)) {
+        // Loop through all currently mapped roles and remove them from the user.
+        foreach ($mappedDrupalRoles as $drupalRole) {
+          if ($user->hasRole($drupalRole)) {
+            $save = TRUE;
+            $user->removeRole($drupalRole);
+          }
         }
-      }
 
-      // Loop through all the Auth0 Roles and apply them to the user.
-      foreach ($auth0UserRoles as $roleId) {
-        if (!empty($roleMapping[$roleId])) {
-          $save = TRUE;
-          $user->addRole($roleMapping[$roleId]);
+        // Loop through all the Auth0 Roles and apply them to the user.
+        foreach ($auth0UserRoles as $roleId) {
+          if (!empty($roleMapping[$roleId])) {
+            $save = TRUE;
+            $user->addRole($roleMapping[$roleId]);
+          }
         }
       }
 


### PR DESCRIPTION
https://kanopi.teamwork.com/app/tasks/29777271

If getUserRoles() returns a 404 'User does not exist' response, `$auth0UserRoles` will be empty. Role mapping first removes the user's roles before adding them back. End result: User account has no roles.

Fix: Check if roles are empty before removing roles.